### PR TITLE
CellとStreamのメソッドのインタフェースを変更

### DIFF
--- a/src/cell.rs
+++ b/src/cell.rs
@@ -138,7 +138,7 @@ where
     pub fn map<B, FN>(&self, f: FN) -> Cell<B>
     where
         B: Clone + Send + 'static,
-        FN: IsLambda1<A, B> + Send + Sync + 'static,
+        FN: FnMut(&A) -> B + Send + Sync + 'static,
     {
         Cell {
             impl_: self.impl_.map(f),
@@ -152,7 +152,7 @@ where
     where
         B: Clone + Send + 'static,
         C: Clone + Send + 'static,
-        FN: IsLambda2<A, B, C> + Send + 'static,
+        FN: FnMut(&A, &B) -> C + Send + 'static,
     {
         Cell {
             impl_: self.impl_.lift2(&cb.impl_, f),
@@ -167,7 +167,7 @@ where
         B: Clone + Send + 'static,
         C: Clone + Send + 'static,
         D: Clone + Send + 'static,
-        FN: IsLambda3<A, B, C, D> + Send + 'static,
+        FN: FnMut(&A, &B, &C) -> D + Send + 'static,
     {
         Cell {
             impl_: self.impl_.lift3(&cb.impl_, &cc.impl_, f),
@@ -183,7 +183,7 @@ where
         C: Clone + Send + 'static,
         D: Clone + Send + 'static,
         E: Clone + Send + 'static,
-        FN: IsLambda4<A, B, C, D, E> + Send + 'static,
+        FN: FnMut(&A, &B, &C, &D) -> E + Send + 'static,
     {
         Cell {
             impl_: self.impl_.lift4(&cb.impl_, &cc.impl_, &cd.impl_, f),
@@ -207,7 +207,7 @@ where
         D: Clone + Send + 'static,
         E: Clone + Send + 'static,
         F: Clone + Send + 'static,
-        FN: IsLambda5<A, B, C, D, E, F> + Send + 'static,
+        FN: FnMut(&A, &B, &C, &D, &E) -> F + Send + 'static,
     {
         Cell {
             impl_: self
@@ -235,7 +235,7 @@ where
         E: Clone + Send + 'static,
         F: Clone + Send + 'static,
         G: Clone + Send + 'static,
-        FN: IsLambda6<A, B, C, D, E, F, G> + Send + 'static,
+        FN: FnMut(&A, &B, &C, &D, &E, &F) -> G + Send + 'static,
     {
         Cell {
             impl_: self

--- a/src/cell.rs
+++ b/src/cell.rs
@@ -1,10 +1,5 @@
 use crate::impl_::cell::Cell as CellImpl;
 use crate::impl_::lambda::IsLambda1;
-use crate::impl_::lambda::IsLambda2;
-use crate::impl_::lambda::IsLambda3;
-use crate::impl_::lambda::IsLambda4;
-use crate::impl_::lambda::IsLambda5;
-use crate::impl_::lambda::IsLambda6;
 use crate::impl_::lazy::Lazy;
 use crate::listener::Listener;
 use crate::sodium_ctx::SodiumCtx;

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -82,7 +82,7 @@ where
     where
         B: Clone + Send + 'static,
         C: Clone + Send + 'static,
-        FN: IsLambda2<A, B, C> + Send + Sync + 'static,
+        FN: FnMut(&A, &B) -> C + Send + Sync + 'static,
     {
         Stream {
             impl_: self.impl_.snapshot(&cb.impl_, f),
@@ -106,7 +106,7 @@ where
         B: Send + Clone + 'static,
         C: Send + Clone + 'static,
         D: Send + Clone + 'static,
-        FN: IsLambda3<A, B, C, D> + Send + Sync + 'static,
+        FN: FnMut(&A, &B, &C) -> D + Send + Sync + 'static,
     {
         Stream {
             impl_: self.impl_.snapshot3(&cb.impl_, &cc.impl_, f),
@@ -127,7 +127,7 @@ where
         C: Send + Clone + 'static,
         D: Send + Clone + 'static,
         E: Send + Clone + 'static,
-        FN: IsLambda4<A, B, C, D, E> + Send + Sync + 'static,
+        FN: FnMut(&A, &B, &C, &D) -> E + Send + Sync + 'static,
     {
         Stream {
             impl_: self.impl_.snapshot4(&cb.impl_, &cc.impl_, &cd.impl_, f),
@@ -150,7 +150,7 @@ where
         D: Send + Clone + 'static,
         E: Send + Clone + 'static,
         F: Send + Clone + 'static,
-        FN: IsLambda5<A, B, C, D, E, F> + Send + Sync + 'static,
+        FN: FnMut(&A, &B, &C, &D, &E) -> F + Send + Sync + 'static,
     {
         Stream {
             impl_: self
@@ -177,7 +177,7 @@ where
         E: Send + Clone + 'static,
         F: Send + Clone + 'static,
         G: Send + Clone + 'static,
-        FN: IsLambda6<A, B, C, D, E, F, G> + Send + Sync + 'static,
+        FN: FnMut(&A, &B, &C, &D, &E, &F) -> G + Send + Sync + 'static,
     {
         Stream {
             impl_: self
@@ -196,7 +196,7 @@ where
     pub fn map<B, FN>(&self, f: FN) -> Stream<B>
     where
         B: Send + Clone + 'static,
-        FN: IsLambda1<A, B> + Send + Sync + 'static,
+        FN: FnMut(&A) -> B + Send + Sync + 'static,
     {
         Stream {
             impl_: self.impl_.map(f),
@@ -214,7 +214,7 @@ where
     /// Return a `Stream` that only outputs events for which the predicate returns `true`.
     pub fn filter<PRED>(&self, pred: PRED) -> Stream<A>
     where
-        PRED: IsLambda1<A, bool> + Send + Sync + 'static,
+        PRED: FnMut(&A) -> bool + Send + Sync + 'static,
     {
         Stream {
             impl_: self.impl_.filter(pred),
@@ -248,7 +248,7 @@ where
     /// appear at the right.
     pub fn merge<FN>(&self, s2: &Stream<A>, f: FN) -> Stream<A>
     where
-        FN: IsLambda2<A, A, A> + Send + Sync + 'static,
+        FN: FnMut(&A, &A) -> A + Send + Sync + 'static,
     {
         Stream {
             impl_: self.impl_.merge(&s2.impl_, f),
@@ -295,7 +295,7 @@ where
     where
         B: Send + Clone + 'static,
         S: Send + Clone + 'static,
-        F: IsLambda2<A, S, (B, S)> + Send + Sync + 'static,
+        F: FnMut(&A, &S) -> (B, S) + Send + Sync + 'static,
     {
         self.collect_lazy(Lazy::new(move || init_state.clone()), f)
     }
@@ -306,7 +306,7 @@ where
     where
         B: Send + Clone + 'static,
         S: Send + Clone + 'static,
-        F: IsLambda2<A, S, (B, S)> + Send + Sync + 'static,
+        F: FnMut(&A, &S) -> (B, S) + Send + Sync + 'static,
     {
         Stream {
             impl_: self.impl_.collect_lazy(init_state, f),
@@ -324,7 +324,7 @@ where
     pub fn accum<S, F>(&self, init_state: S, f: F) -> Cell<S>
     where
         S: Send + Clone + 'static,
-        F: IsLambda2<A, S, S> + Send + Sync + 'static,
+        F: FnMut(&A, &S) -> S + Send + Sync + 'static,
     {
         self.accum_lazy(Lazy::new(move || init_state.clone()), f)
     }
@@ -334,7 +334,7 @@ where
     pub fn accum_lazy<S, F>(&self, init_state: Lazy<S>, f: F) -> Cell<S>
     where
         S: Send + Clone + 'static,
-        F: IsLambda2<A, S, S> + Send + Sync + 'static,
+        F: FnMut(&A, &S) -> S + Send + Sync + 'static,
     {
         Cell {
             impl_: self.impl_.accum_lazy(init_state, f),
@@ -349,7 +349,7 @@ where
     /// deregistered if [`Listener::unlisten`] is called explicitly.
     pub fn listen_weak<K>(&self, k: K) -> Listener
     where
-        K: IsLambda1<A, ()> + Send + Sync + 'static,
+        K: FnMut(&A) -> () + Send + Sync + 'static,
     {
         Listener {
             impl_: self.impl_.listen_weak(k),
@@ -370,7 +370,7 @@ where
     /// [`StreamSink::send`][crate::StreamSink::send] in the handler.
     pub fn listen<K>(&self, k: K) -> Listener
     where
-        K: IsLambda1<A, ()> + Send + Sync + 'static,
+        K: FnMut(&A) -> () + Send + Sync + 'static,
     {
         Listener {
             impl_: self.impl_.listen(k),

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -1,6 +1,5 @@
 use crate::cell::Cell;
 use crate::impl_::dep::Dep;
-use crate::impl_::lambda::{IsLambda1, IsLambda2, IsLambda3, IsLambda4, IsLambda5, IsLambda6};
 use crate::impl_::stream::Stream as StreamImpl;
 use crate::listener::Listener;
 use crate::sodium_ctx::SodiumCtx;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,4 +1,4 @@
-use crate::{lambda1, Cell, CellLoop, Operational, SodiumCtx, Stream, StreamLoop, StreamSink};
+use crate::{Cell, CellLoop, Operational, SodiumCtx, Stream, StreamLoop, StreamSink};
 
 use std::sync::{Arc, Mutex};
 
@@ -1256,11 +1256,8 @@ fn switch_c() {
         let ca = ssc.stream().map(|s: &SC| s.a).filter_option().hold("A");
         let cb = ssc.stream().map(|s: &SC| s.b).filter_option().hold("a");
         let csw_str = ssc.stream().map(|s: &SC| s.sw).filter_option().hold("ca");
-        let csw_deps = vec![ca.to_dep(), cb.to_dep()];
-        let csw = csw_str.map(lambda1(
-            move |s: &&'static str| if *s == "ca" { ca.clone() } else { cb.clone() },
-            csw_deps,
-        ));
+        let csw =
+            csw_str.map(move |s: &&'static str| if *s == "ca" { ca.clone() } else { cb.clone() });
         let co = Cell::switch_c(&csw);
         let out = Arc::new(Mutex::new(Vec::new()));
         {
@@ -1311,11 +1308,9 @@ fn switch_s() {
         let sa = sss.stream().map(|s: &SS| s.a);
         let sb = sss.stream().map(|s: &SS| s.b);
         let csw_str = sss.stream().map(|s: &SS| s.sw).filter_option().hold("sa");
-        let csw_deps = vec![sa.to_dep(), sb.to_dep()];
-        let csw: Cell<Stream<&'static str>> = csw_str.map(lambda1(
-            move |sw: &&'static str| if *sw == "sa" { sa.clone() } else { sb.clone() },
-            csw_deps,
-        ));
+
+        let csw: Cell<Stream<&'static str>> =
+            csw_str.map(move |sw: &&'static str| if *sw == "sa" { sa.clone() } else { sb.clone() });
         let so = Cell::switch_s(&csw);
         let out = Arc::new(Mutex::new(Vec::<&'static str>::new()));
         {


### PR DESCRIPTION
LambdaNを使用していた部分をFnMutに変更。
これによってラムダ式の指定時に引数の型推論が効くようになる。